### PR TITLE
Config test

### DIFF
--- a/lib/Boris/Config.php
+++ b/lib/Boris/Config.php
@@ -27,7 +27,7 @@ class Config
         $this->_cascade     = (bool) $cascade;
         $this->_searchPaths = is_array($searchPaths) ? $searchPaths : null;
 
-        if (is_null($searchPaths)) {
+        if (is_null($this->_searchPaths)) {
             $this->_searchPaths = array();
 
             if ($userHome = getenv('HOME')) {

--- a/lib/Boris/Config.php
+++ b/lib/Boris/Config.php
@@ -54,7 +54,7 @@ class Config
 
         foreach ($this->_searchPaths as $path) {
             if (is_readable($path)) {
-                $this->_loadInIsolation($path, $boris);
+                $this->_loadInIsolation($path);
 
                 $applied        = true;
                 $this->_files[] = $path;
@@ -81,7 +81,7 @@ class Config
 
     // -- Private Methods
 
-    private function _loadInIsolation($path, $boris)
+    private function _loadInIsolation($path)
     {
         require $path;
     }

--- a/lib/Boris/Config.php
+++ b/lib/Boris/Config.php
@@ -40,8 +40,7 @@ class Config
 
     /**
      * Searches for configuration files in the available
-     * search paths, and applies them to the provided
-     * boris instance.
+     * search paths, and applies them.
      *
      * Returns true if any configuration files were found.
      *

--- a/lib/Boris/Config.php
+++ b/lib/Boris/Config.php
@@ -45,10 +45,9 @@ class Config
      *
      * Returns true if any configuration files were found.
      *
-     * @param  Boris\Boris $boris
      * @return bool
      */
-    public function apply(Boris $boris)
+    public function apply()
     {
         $applied = false;
 

--- a/lib/Boris/Config.php
+++ b/lib/Boris/Config.php
@@ -28,13 +28,13 @@ class Config
         $this->_searchPaths = is_array($searchPaths) ? $searchPaths : null;
 
         if (is_null($searchPaths)) {
-            $searchPaths = array();
+            $this->_searchPaths = array();
 
             if ($userHome = getenv('HOME')) {
-                $searchPaths[] = "{$userHome}/.borisrc";
+                $this->_searchPaths[] = "{$userHome}/.borisrc";
             }
 
-            $searchPaths[] = getcwd() . '/.borisrc';
+            $this->_searchPaths[] = getcwd() . '/.borisrc';
         }
     }
 

--- a/lib/Boris/Config.php
+++ b/lib/Boris/Config.php
@@ -10,7 +10,7 @@ class Config
     private $_searchPaths;
     private $_cascade = false;
     private $_files = array();
-    
+
     /**
      * Create a new Config instance, optionally with an array
      * of paths to search for configuration files.
@@ -24,20 +24,20 @@ class Config
      */
     public function __construct($searchPaths = null, $cascade = false)
     {
+        $this->_cascade     = (bool) $cascade;
+        $this->_searchPaths = is_array($searchPaths) ? $searchPaths : null;
+
         if (is_null($searchPaths)) {
             $searchPaths = array();
-            
+
             if ($userHome = getenv('HOME')) {
                 $searchPaths[] = "{$userHome}/.borisrc";
             }
-            
+
             $searchPaths[] = getcwd() . '/.borisrc';
         }
-        
-        $this->_cascade     = $cascade;
-        $this->_searchPaths = $searchPaths;
     }
-    
+
     /**
      * Searches for configuration files in the available
      * search paths, and applies them to the provided
@@ -51,23 +51,23 @@ class Config
     public function apply(Boris $boris)
     {
         $applied = false;
-        
+
         foreach ($this->_searchPaths as $path) {
             if (is_readable($path)) {
                 $this->_loadInIsolation($path, $boris);
-                
+
                 $applied        = true;
                 $this->_files[] = $path;
-                
+
                 if (!$this->_cascade) {
                     break;
                 }
             }
         }
-        
+
         return $applied;
     }
-    
+
     /**
      * Returns an array of files that were loaded
      * for this Config
@@ -78,9 +78,9 @@ class Config
     {
         return $this->_files;
     }
-    
+
     // -- Private Methods
-    
+
     private function _loadInIsolation($path, $boris)
     {
         require $path;

--- a/tests/lib/Boris/ConfigTest.php
+++ b/tests/lib/Boris/ConfigTest.php
@@ -88,7 +88,20 @@ extends \PHPUnit_Framework_TestCase
      * Tests the apply method.
      */
     public function test_apply () {
+      //setup
+      $test_file_to_apply = getcwd() . '/tests/requirable.php';
+      $test_file_to_apply2 = getcwd() . '/tests/requirable2.php';
+      $files = array($test_file_to_apply, $test_file_to_apply2);
 
+      // without cascade
+      $Config = new Config($files);
+      $Config->apply();
+      $this->assertEquals(getenv('REQUIRED_MESSAGE'), 'You successfully required the file!');
+
+      // with cascade
+      $Config = new Config($files, true);
+      $Config->apply();
+      $this->assertEquals(getenv('REQUIRED_MESSAGE'), 'You successfully required the 2nd file!');
     }
 
     /**

--- a/tests/lib/Boris/ConfigTest.php
+++ b/tests/lib/Boris/ConfigTest.php
@@ -44,7 +44,7 @@ extends \PHPUnit_Framework_TestCase
      */
     public function test_constructor_params () {
       // test of good parameters
-      $path1 = '/path/tp/awesome';
+      $path1 = '/path/to/awesome';
       $path2 = '/dev/random';
       $Config = new Config(array($path1, $path2), true);
 

--- a/tests/lib/Boris/ConfigTest.php
+++ b/tests/lib/Boris/ConfigTest.php
@@ -60,6 +60,28 @@ extends \PHPUnit_Framework_TestCase
       $this->assertContains('[1] => ' . $path2, $class);
       $this->assertContains('[_cascade:Boris\Config:private] => 1', $class);
       $this->assertContains('[_files:Boris\Config:private] => Array', $class);
+
+      // test of bad params
+      $Config = new Config('not an array', 27);
+
+      // since all the class variables are private...
+      ob_start();
+      print_r($Config);
+      $class = ob_get_contents();
+      ob_end_clean();
+
+      // check class vars exist
+      $this->assertContains('[_searchPaths:Boris\Config:private] => Array', $class);
+      $this->assertContains('[_cascade:Boris\Config:private]', $class);
+      $this->assertContains('[_files:Boris\Config:private] => Array', $class);
+
+      // check _searchPaths are initialized properly
+      $pwd = getcwd() . '/.borisrc';
+      $this->assertContains('] => ' . $pwd, $class);
+      if (getenv('HOME')) {
+          $home = getenv('HOME').'/.borisrc';
+          $this->assertContains('[0] => ' . $home, $class);
+      }
     }
 
     /**

--- a/tests/lib/Boris/ConfigTest.php
+++ b/tests/lib/Boris/ConfigTest.php
@@ -43,7 +43,12 @@ extends \PHPUnit_Framework_TestCase
      * Tests the constructor with parameters.
      */
     public function test_constructor_params () {
+      // test of good parameters
+      $path1 = '/path/tp/awesome';
+      $path2 = '/dev/random';
+      $Config = new Config(array($path1, $path2), true);
 
+      print_r($Config);
     }
 
     /**

--- a/tests/lib/Boris/ConfigTest.php
+++ b/tests/lib/Boris/ConfigTest.php
@@ -32,10 +32,10 @@ extends \PHPUnit_Framework_TestCase
 
       // check _searchPaths are initialized properly
       $pwd = getcwd() . '/.borisrc';
-      $this->assertContains('] => '.$pwd, $class);
+      $this->assertContains('] => ' . $pwd, $class);
       if (getenv('HOME')) {
           $home = getenv('HOME').'/.borisrc';
-          $this->assertContains('[0] => '.$home, $class);
+          $this->assertContains('[0] => ' . $home, $class);
       }
     }
 
@@ -48,7 +48,18 @@ extends \PHPUnit_Framework_TestCase
       $path2 = '/dev/random';
       $Config = new Config(array($path1, $path2), true);
 
+      // since all the class variables are private...
+      ob_start();
       print_r($Config);
+      $class = ob_get_contents();
+      ob_end_clean();
+
+      // check class vars exist
+      $this->assertContains('[_searchPaths:Boris\Config:private] => Array', $class);
+      $this->assertContains('[0] => ' . $path1, $class);
+      $this->assertContains('[1] => ' . $path2, $class);
+      $this->assertContains('[_cascade:Boris\Config:private] => 1', $class);
+      $this->assertContains('[_files:Boris\Config:private] => Array', $class);
     }
 
     /**

--- a/tests/lib/Boris/ConfigTest.php
+++ b/tests/lib/Boris/ConfigTest.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This class tests lib/autoload.php
+ *
+ * To run this individual test:
+ *
+ * phpunit --bootstrap tests/autoload.php tests/lib/Boris/ConfigTest --coverage-html ./reports
+ *
+ */
+namespace tests\lib\Boris;
+use \Boris\Config as Config;
+
+class ConfigTest
+extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests the constructor.
+     */
+    public function test_constructor () {
+
+    }
+
+    /**
+     * Tests the apply method.
+     */
+    public function test_apply () {
+
+    }
+
+    /**
+     * Tests the loadedFiles method.
+     */
+    public function test_loadedFiles () {
+
+    }
+}

--- a/tests/lib/Boris/ConfigTest.php
+++ b/tests/lib/Boris/ConfigTest.php
@@ -14,9 +14,35 @@ class ConfigTest
 extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Tests the constructor.
+     * Tests the constructor with no parameters.
      */
-    public function test_constructor () {
+    public function test_constructor_no_params () {
+      $Config = new Config();
+
+      // since all the class variables are private...
+      ob_start();
+      print_r($Config);
+      $class = ob_get_contents();
+      ob_end_clean();
+
+      // check class vars exist
+      $this->assertContains('[_searchPaths:Boris\Config:private] => Array', $class);
+      $this->assertContains('[_cascade:Boris\Config:private]', $class);
+      $this->assertContains('[_files:Boris\Config:private] => Array', $class);
+
+      // check _searchPaths are initialized properly
+      $pwd = getcwd() . '/.borisrc';
+      $this->assertContains('] => '.$pwd, $class);
+      if (getenv('HOME')) {
+          $home = getenv('HOME').'/.borisrc';
+          $this->assertContains('[0] => '.$home, $class);
+      }
+    }
+
+    /**
+     * Tests the constructor with parameters.
+     */
+    public function test_constructor_params () {
 
     }
 

--- a/tests/lib/Boris/ConfigTest.php
+++ b/tests/lib/Boris/ConfigTest.php
@@ -108,6 +108,15 @@ extends \PHPUnit_Framework_TestCase
      * Tests the loadedFiles method.
      */
     public function test_loadedFiles () {
-
+      $test_file_to_apply = getcwd() . '/tests/requirable.php';
+      $test_file_to_apply2 = getcwd() . '/tests/requirable2.php';
+      $test_file_to_apply3 ='/this/path/is/fake/and/will/fail';
+      $files = array($test_file_to_apply, $test_file_to_apply2, $test_file_to_apply3);
+      $Config = new Config($files, true);
+      $Config->apply();
+      $files = $Config->loadedFiles();
+      $this->assertEquals(2, count($files));
+      $this->assertEquals($test_file_to_apply, $files[0]);
+      $this->assertEquals($test_file_to_apply2, $files[1]);
     }
 }

--- a/tests/lib/Boris/DumpInspectorTest.php
+++ b/tests/lib/Boris/DumpInspectorTest.php
@@ -32,7 +32,7 @@ extends \PHPUnit_Framework_TestCase
       // random float
       $variable = (float) rand();
       $test = $DumpInspector->inspect($variable);
-      //$this->assertEquals(" → float($variable)", $test);
+      $this->assertEquals(" → float($variable)", $test);
 
       // random array
       $k = rand();

--- a/tests/lib/Boris/DumpInspectorTest.php
+++ b/tests/lib/Boris/DumpInspectorTest.php
@@ -32,7 +32,7 @@ extends \PHPUnit_Framework_TestCase
       // random float
       $variable = (float) rand();
       $test = $DumpInspector->inspect($variable);
-      $this->assertEquals(" → float($variable)", $test);
+      //$this->assertEquals(" → float($variable)", $test);
 
       // random array
       $k = rand();

--- a/tests/requirable.php
+++ b/tests/requirable.php
@@ -1,0 +1,3 @@
+<?php
+putenv('REQUIRED_MESSAGE=You successfully required the file!');
+?>

--- a/tests/requirable2.php
+++ b/tests/requirable2.php
@@ -1,0 +1,2 @@
+<?php
+putenv('REQUIRED_MESSAGE=You successfully required the 2nd file!');?>


### PR DESCRIPTION
Removed some unused parameters and added some type checking to Config class.

Test class for Config class.

Not sure why Travis has changed the way var_dump() works in PHP5, but I think it's something on their end. PHP& & HHVM are still working fine and Composer appears to be out of date for the PHP5 versions. Time will tell I suppose...